### PR TITLE
Remove 'head' from atomic tag list, as that broke things for me

### DIFF
--- a/js/htmldiff.js
+++ b/js/htmldiff.js
@@ -69,8 +69,9 @@
      * @see function diff.
      */
     var atomicTagsRegExp;
-    // Added head and style (for style tags inside the body)
-    var defaultAtomicTagsRegExp = new RegExp('^<(iframe|object|math|svg|script|video|head|style)');
+    // Added style (for style tags inside the body)
+    // @github.com/aziraphale: Had to remove 'head' as it broke things for me
+    var defaultAtomicTagsRegExp = new RegExp('^<(iframe|object|math|svg|script|video|style)');
     
     /**
      * Checks if the current word is the beginning of an atomic tag. An atomic tag is one whose


### PR DESCRIPTION
I had to remove the `<head>` tag from the list of atomic tags, because with that included, this script ignored any changes in the main content area of this page: https://www.parcelforce.com/service-updates (e.g. I tried adjusting the text inside one of the country drop-downs)

(In case Parcelforce completely change the HTML of that page in the future, here's a version downloaded with `wget --convert-links` for reference: [2018-09-28.html.txt](https://github.com/idesis-gmbh/htmldiff.js/files/2431565/2018-09-28.html.txt))

My only guess is that it might be due to that page including a `<header>` tag, but the content I was changing wasn't within the `<header>` tag, so I'm not too sure.

I tried stripping out all kinds of tags from that page's HTML in an attempt to make the difference be picked up but without any real success. I also tried running the page through the latest version of Tidy, and that didn't help.

I also tried tweaking the atomic tag regex so that it only looked for whole tag names matching the list of atmoic tags, using a `\b` match, e.g.:
```new RegExp('^<(iframe|object|math|svg|script|video|head|style)\b');```
but that didn't seem to fix the problem, so I'm quite lost at this point.

Unfortunately I've looked into this for as long as I can really get away with at work - as it is I may face my boss' wrath next week! - so I can't spend any longer pinning down the issue or writing unit tests. Hopefully you can figure this one out 😸 